### PR TITLE
fix postcss vulnerability pinned by next.js

### DIFF
--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -3183,33 +3183,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
@@ -6606,21 +6579,9 @@
         "@next/swc-win32-x64-msvc": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.10",
         "sharp": "^0.34.3",
         "styled-jsx": "5.1.6"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "8.4.31",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-          "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-          "requires": {
-            "nanoid": "^3.3.6",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        }
       }
     },
     "node-releases": {
@@ -7309,7 +7270,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "postcss": "8.5.10",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
         "postcss-load-config": "^4.0.1",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "overrides": {
+    "postcss": "$postcss"
+  },
   "dependencies": {
     "@types/node": "20.3.1",
     "@types/react": "18.2.13",


### PR DESCRIPTION
## Summary

- Add npm `overrides` in `nextjs/package.json` to force all transitive `postcss` dependencies to resolve to `^8.5.10`, fixing the moderate vulnerability (`postcss@8.4.31`) that Next.js pins internally.
- Verified with `npm ls postcss` that all resolved versions are `8.5.10` and `npm audit` reports 0 vulnerabilities.